### PR TITLE
CI: Remove `cron` schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,7 @@ on:
       - "v*"
     tags:
       - "v*"
-  pull_request: {}
-  schedule:
-    - cron:  '0 3 * * *' # daily, at 3am
+  pull_request:
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
This is causing the job to be disabled due to the blockchain scammers...