### PR TITLE
Drop support for Node.js 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   test-node:
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     name: Tests (Node.js ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   },
   "peerDependencies": {
     "eslint": "^7.11.0"
+  },
+  "engines": {
+    "node": "12.* || 14.* || >= 16.*"
   }
 }


### PR DESCRIPTION
Since we haven't released this package yet, this is technically not a breaking change, but I'll label it like that anyway... 🤷‍♂️ 