### PR TITLE
rules: Use `messageId` instead of `message`

### DIFF
--- a/rules/no-checked-selector.js
+++ b/rules/no-checked-selector.js
@@ -1,8 +1,4 @@
-const message = "use assert.dom('.foo').isChecked() instead assert.dom('.foo:checked').exists()";
-
 module.exports = {
-  message,
-
   meta: {
     type: 'suggestion',
     docs: {
@@ -11,6 +7,9 @@ module.exports = {
       url: 'https://github.com/simplabs/eslint-plugin-qunit-dom/blob/main/rules/no-checked-selector.md',
     },
     schema: [],
+    messages: {
+      default: "use assert.dom('.foo').isChecked() instead of assert.dom('.foo:checked').exists()",
+    },
   },
 
   create(context) {
@@ -43,7 +42,7 @@ module.exports = {
 
         context.report({
           node: node,
-          message,
+          messageId: 'default',
         });
       },
     };

--- a/rules/no-checked-selector.test.js
+++ b/rules/no-checked-selector.test.js
@@ -29,7 +29,7 @@ ruleTester.run('no-checked-selector', rule, {
       code: "assert.dom('.foo:checked').exists()",
       errors: [
         {
-          message: rule.message,
+          messageId: 'default',
           column: 1,
           endColumn: 27,
         },

--- a/rules/no-ok-find.js
+++ b/rules/no-ok-find.js
@@ -1,8 +1,4 @@
-const message = 'use assert.dom(...).exists() instead assert.ok(find(...))';
-
 module.exports = {
-  message,
-
   meta: {
     type: 'suggestion',
     docs: {
@@ -12,6 +8,9 @@ module.exports = {
     },
     fixable: 'code',
     schema: [],
+    messages: {
+      default: 'use assert.dom(...).exists() instead assert.ok(find(...))',
+    },
   },
 
   create(context) {
@@ -41,7 +40,7 @@ module.exports = {
 
         context.report({
           node: node.parent,
-          message,
+          messageId: 'default',
           fix(fixer) {
             let findArgText = sourceCode.getText(firstArg.arguments[0]);
             let messageArg = node.parent.arguments[1];

--- a/rules/no-ok-find.test.js
+++ b/rules/no-ok-find.test.js
@@ -34,7 +34,7 @@ ruleTester.run('no-ok-find', rule, {
       output: "assert.dom('.foo').exists('bar')",
       errors: [
         {
-          message: rule.message,
+          messageId: 'default',
           column: 1,
           endColumn: 31,
         },
@@ -45,7 +45,7 @@ ruleTester.run('no-ok-find', rule, {
       output: "assert.dom('.foo').exists()",
       errors: [
         {
-          message: rule.message,
+          messageId: 'default',
           column: 1,
           endColumn: 24,
         },
@@ -57,7 +57,7 @@ ruleTester.run('no-ok-find', rule, {
       output: "assert.dom('.foo').doesNotExist('bar')",
       errors: [
         {
-          message: rule.message,
+          messageId: 'default',
           column: 1,
           endColumn: 34,
         },
@@ -68,7 +68,7 @@ ruleTester.run('no-ok-find', rule, {
       output: "assert.dom('.foo').doesNotExist()",
       errors: [
         {
-          message: rule.message,
+          messageId: 'default',
           column: 1,
           endColumn: 27,
         },


### PR DESCRIPTION
see https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-message-ids.md