### PR TITLE
Automatically export all rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,22 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+
 module.exports = {
-  rules: {
-    'no-ok-find': require('./rules/no-ok-find'),
-  },
+  rules: generateRulesMap(),
 };
+
+function generateRulesMap() {
+  let rulesPath = path.join(__dirname, 'rules');
+  let files = fs.readdirSync(rulesPath);
+
+  let rulesMap = {};
+  for (let file of files) {
+    if (file.endsWith('.js') && !file.endsWith('.test.js')) {
+      let ruleName = path.parse(file).name;
+      rulesMap[ruleName] = require(`./rules/${file}`);
+    }
+  }
+  return rulesMap;
+}


### PR DESCRIPTION
This resolves the issue that `no-checked-selector` was currently not exported at all.