### PR TITLE
Export `recommended` ESLint config

### DIFF
--- a/configs.test.js
+++ b/configs.test.js
@@ -1,0 +1,18 @@
+describe('configs', () => {
+  it('recommended is stable', () => {
+    // if you change the list of recommended rules, make sure to release this
+    // as a breaking change!!
+
+    expect(require('./index').configs.recommended).toMatchInlineSnapshot(`
+Object {
+  "plugins": Array [
+    "qunit-dom",
+  ],
+  "rules": Object {
+    "qunit-dom/no-checked-selector": "error",
+    "qunit-dom/no-ok-find": "error",
+  },
+}
+`);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -3,8 +3,13 @@
 const fs = require('fs');
 const path = require('path');
 
+const rules = generateRulesMap();
+
 module.exports = {
-  rules: generateRulesMap(),
+  configs: {
+    recommended: generateRecommendedConfig(rules),
+  },
+  rules,
 };
 
 function generateRulesMap() {
@@ -19,4 +24,20 @@ function generateRulesMap() {
     }
   }
   return rulesMap;
+}
+
+function generateRecommendedConfig(rules) {
+  let config = {
+    plugins: ['qunit-dom'],
+    rules: {},
+  };
+
+  for (let ruleName of Object.keys(rules)) {
+    let rule = rules[ruleName];
+    if (rule.meta.docs.recommended) {
+      config.rules[`qunit-dom/${ruleName}`] = 'error';
+    }
+  }
+
+  return config;
 }


### PR DESCRIPTION
This should make the plugin a little easier to use.

Note that adding rules to this list should be considered a breaking change!