### PR TITLE
ESLint: Enable for hidden files too

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /coverage
+!.*

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,9 +1,9 @@
 'use strict';
 
 module.exports = {
-    printWidth: 100,
-    semi: true,
-    arrowParens: 'avoid',
-    singleQuote: true,
-    trailingComma: 'es5',
+  printWidth: 100,
+  semi: true,
+  arrowParens: 'avoid',
+  singleQuote: true,
+  trailingComma: 'es5',
 };


### PR DESCRIPTION
By default, ESLint only runs on non-hidden files, but we want it to run on **all** JS files.