### PR TITLE
Reimplement `no-ok-find` rule

### DIFF
--- a/rules/no-ok-find.js
+++ b/rules/no-ok-find.js
@@ -1,3 +1,47 @@
+const OK_OR_NOTOK_SELECTOR =
+  'CallExpression' +
+  '[callee.type="MemberExpression"]' +
+  '[callee.object.name="assert"]' +
+  '[callee.property.name=/(ok|notOk)/]' +
+  '[arguments.length>=1]';
+
+const EQUAL_SELECTOR =
+  'CallExpression' +
+  '[callee.type="MemberExpression"]' +
+  '[callee.object.name="assert"]' +
+  '[callee.property.name="equal"]' +
+  '[arguments.length>=2]' +
+  '[arguments.1.type="Literal"]';
+
+// see https://api.jquery.com/category/selectors/jquery-selector-extensions/
+const JQUERY_SELECTOR_EXTENSIONS = [
+  ':animated',
+  ':button',
+  ':checkbox',
+  ':contains(',
+  ':eq(',
+  ':even',
+  ':file',
+  ':first',
+  ':gt(',
+  ':has(',
+  ':header',
+  ':hidden',
+  ':image',
+  ':input',
+  ':last',
+  ':lt(',
+  ':odd',
+  ':parent',
+  ':password',
+  ':radio',
+  ':reset',
+  ':selected',
+  ':submit',
+  ':text',
+  ':visible',
+];
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -9,7 +53,10 @@ module.exports = {
     fixable: 'code',
     schema: [],
     messages: {
-      default: 'use assert.dom(...).exists() instead assert.ok(find(...))',
+      ok: 'use assert.dom(...).exists() instead assert.ok(find(...))',
+      'not-ok': 'use assert.dom(...).doesNotExists() instead assert.notOk(find(...))',
+      'equal-true': 'use assert.dom(...).exists() instead assert.equal(find(...), true)',
+      'equal-false': 'use assert.dom(...).doesNotExists() instead assert.equal(find(...), false)',
     },
   },
 
@@ -17,39 +64,74 @@ module.exports = {
     let sourceCode = context.getSourceCode();
 
     return {
-      MemberExpression(node) {
-        if (node.object.type !== 'Identifier') return;
-        if (node.object.name !== 'assert') return;
-        if (node.property.type !== 'Identifier') return;
-        let inverted = false;
+      [OK_OR_NOTOK_SELECTOR](node) {
+        let inverted = node.callee.property.name === 'notOk';
 
-        if (node.property.name === 'notOk') {
-          inverted = true;
-        } else if (node.property.name !== 'ok') {
-          return;
-        }
+        let firstArg = node.arguments[0];
+        if (!isFindCall(firstArg) && !isIndexedFindCall(firstArg)) return;
 
-        if (!node.parent) return;
-        if (node.parent.type !== 'CallExpression') return;
-        let firstArg = node.parent.arguments[0];
-        if (!firstArg) return;
-        if (firstArg.type !== 'CallExpression') return;
-        if (firstArg.callee.type !== 'Identifier') return;
-        if (firstArg.callee.name !== 'find') return;
-        if (firstArg.arguments.length !== 1) return;
+        let findNode = firstArg.type === 'MemberExpression' ? firstArg.object : firstArg;
+        let firstFindArg = findNode.arguments[0];
+        if (!isValidFindArg(firstFindArg)) return;
 
         context.report({
-          node: node.parent,
-          messageId: 'default',
+          node: node,
+          messageId: inverted ? 'not-ok' : 'ok',
+
           fix(fixer) {
-            let findArgText = sourceCode.getText(firstArg.arguments[0]);
-            let messageArg = node.parent.arguments[1];
-            let messageArgText = messageArg ? sourceCode.getText(messageArg) : '';
+            let domArgs = sourceCode.getText(firstFindArg);
+            let scopeArg = findNode.arguments[1];
+            if (scopeArg && scopeArg.type === 'Literal' && typeof scopeArg.value === 'string') {
+              domArgs += ', ';
+              domArgs += sourceCode.getText(scopeArg);
+            }
+
             let assertion = inverted ? 'doesNotExist' : 'exists';
 
+            let messageArg = node.arguments[1];
+            let messageArgText = messageArg ? sourceCode.getText(messageArg) : '';
+
             return fixer.replaceText(
-              node.parent,
-              `assert.dom(${findArgText}).${assertion}(${messageArgText})`
+              node,
+              `assert.dom(${domArgs}).${assertion}(${messageArgText})`
+            );
+          },
+        });
+      },
+
+      [EQUAL_SELECTOR](node) {
+        let secondArg = node.arguments[1];
+        if (typeof secondArg.value !== 'boolean') return;
+        let inverted = !secondArg.value;
+
+        let firstArg = node.arguments[0];
+        if (!isFindCall(firstArg) && !isIndexedFindCall(firstArg)) return;
+
+        let findNode = firstArg.type === 'MemberExpression' ? firstArg.object : firstArg;
+        let findArgs = findNode.arguments;
+        let firstFindArg = findArgs[0];
+        if (!isValidFindArg(firstFindArg)) return;
+
+        context.report({
+          node: node,
+          messageId: inverted ? 'equal-false' : 'equal-true',
+
+          fix(fixer) {
+            let domArgs = sourceCode.getText(firstFindArg);
+            let scopeArg = findNode.arguments[1];
+            if (scopeArg && scopeArg.type === 'Literal' && typeof scopeArg.value === 'string') {
+              domArgs += ', ';
+              domArgs += sourceCode.getText(scopeArg);
+            }
+
+            let assertion = inverted ? 'doesNotExist' : 'exists';
+
+            let messageArg = node.arguments[2];
+            let messageArgText = messageArg ? sourceCode.getText(messageArg) : '';
+
+            return fixer.replaceText(
+              node,
+              `assert.dom(${domArgs}).${assertion}(${messageArgText})`
             );
           },
         });
@@ -57,3 +139,30 @@ module.exports = {
     };
   },
 };
+
+// checks for `find(...)`
+function isFindCall(node) {
+  return node.type === 'CallExpression' && node.callee.name === 'find';
+}
+
+// checks for `find(...)[0]`
+function isIndexedFindCall(node) {
+  return (
+    node.type === 'MemberExpression' &&
+    isFindCall(node.object) &&
+    node.property.type === 'Literal' &&
+    node.property.value === 0
+  );
+}
+
+function isValidFindArg(node) {
+  if (!node) return false;
+  if (node.type === 'Literal') {
+    return typeof node.value === 'string' && !hasJQuerySelector(node.value);
+  }
+  return true;
+}
+
+function hasJQuerySelector(selector) {
+  return JQUERY_SELECTOR_EXTENSIONS.some(it => selector.includes(it));
+}

--- a/rules/no-ok-find.test.js
+++ b/rules/no-ok-find.test.js
@@ -11,68 +11,209 @@ let ruleTester = new RuleTester({
 
 ruleTester.run('no-ok-find', rule, {
   valid: [
-    "notAssert.ok(find('.foo'))",
-    "assert.foo(find('.bar'))",
-    'assert.ok',
-    'assert.ok()',
-    'assert.ok(1)',
-    "assert.ok(notFind('.foo'))",
-    "assert.ok(find('.foo', '.bar'))",
-    'assert.ok(find())',
+    "notAssert.ok(find('.foo'));",
+    "assert.foo(find('.bar'));",
+    'assert.ok;',
+    'assert.ok();',
+    'assert.ok(1);',
+    "assert.ok(notFind('.foo'));",
+    'assert.ok(find());',
 
-    "notAssert.notOk(find('.foo'))",
-    'assert.notOk',
-    'assert.notOk()',
-    'assert.notOk(1)',
-    "assert.notOk(notFind('.foo'))",
-    "assert.notOk(find('.foo', '.bar'))",
-    'assert.notOk(find())',
+    "notAssert.notOk(find('.foo'));",
+    'assert.notOk;',
+    'assert.notOk();',
+    'assert.notOk(1);',
+    "assert.notOk(notFind('.foo'));",
+    'assert.notOk(find());',
+
+    // from https://github.com/simplabs/qunit-dom-codemod/blob/master/__testfixtures__/qunit-dom-codemod/ok-find.input.js
+    "assert.ok(find('input:first'));",
+    "assert.ok(find('input:contains(foo)'));",
+    "assert.equal(find('.foo'));",
+    "assert.strictEqual(find('.foo'));",
+    'assert.ok(true);',
+    'assert.equal(foo(), true);',
+    'assert.strictEqual(foo(), true);',
+
+    // from https://github.com/simplabs/qunit-dom-codemod/blob/master/__testfixtures__/qunit-dom-codemod/ok-find.input.js
+    "assert.notOk(find('input:first'));",
+    "assert.notOk(find('input:contains(foo)'));",
+    'assert.notOk(true);',
+
+    "assert.equal(find('.foo'), 'foo');",
+    'assert.equal(find(), true);',
+    'assert.equal(find(42), true);',
+
+    "assert.strictEqual(find('.foo'), true);",
+    "assert.strictEqual(find('.foo')[0], true);",
+    "assert.strictEqual(find('.foo'), true, 'custom message');",
+    "assert.strictEqual(find('.foo')[0], true, 'custom message');",
+    "assert.strictEqual(find('.foo', '.parent-scope'), true);",
+    "assert.strictEqual(find('.foo', '.parent-scope')[0], true);",
+
+    "assert.strictEqual(find('.foo'), false);",
+    "assert.strictEqual(find('.foo')[0], false);",
+    "assert.strictEqual(find('.foo'), false, 'custom message');",
+    "assert.strictEqual(find('.foo')[0], false, 'custom message');",
+    "assert.strictEqual(find('.foo', '.parent-scope'), false);",
+    "assert.strictEqual(find('.foo', '.parent-scope')[0], false);",
   ],
+
   invalid: [
+    // from https://github.com/simplabs/qunit-dom-codemod/blob/master/__testfixtures__/qunit-dom-codemod/ok-find.input.js
+
     {
-      code: "assert.ok(find('.foo'), 'bar')",
-      output: "assert.dom('.foo').exists('bar')",
-      errors: [
-        {
-          messageId: 'default',
-          column: 1,
-          endColumn: 31,
-        },
-      ],
+      code: "assert.ok(find('.foo'));",
+      output: "assert.dom('.foo').exists();",
+      errors: [{ messageId: 'ok' }],
     },
     {
-      code: "assert.ok(find('.foo'))",
-      output: "assert.dom('.foo').exists()",
-      errors: [
-        {
-          messageId: 'default',
-          column: 1,
-          endColumn: 24,
-        },
-      ],
+      code: "assert.ok(find('.foo')[0]);",
+      output: "assert.dom('.foo').exists();",
+      errors: [{ messageId: 'ok' }],
+    },
+    {
+      code: 'assert.ok(find(foo));',
+      output: 'assert.dom(foo).exists();',
+      errors: [{ messageId: 'ok' }],
+    },
+    {
+      code: 'assert.ok(find(foo.bar));',
+      output: 'assert.dom(foo.bar).exists();',
+      errors: [{ messageId: 'ok' }],
     },
 
     {
-      code: "assert.notOk(find('.foo'), 'bar')",
-      output: "assert.dom('.foo').doesNotExist('bar')",
-      errors: [
-        {
-          messageId: 'default',
-          column: 1,
-          endColumn: 34,
-        },
-      ],
+      code: "assert.ok(find('.foo'), 'custom message');",
+      output: "assert.dom('.foo').exists('custom message');",
+      errors: [{ messageId: 'ok' }],
     },
     {
-      code: "assert.notOk(find('.foo'))",
-      output: "assert.dom('.foo').doesNotExist()",
-      errors: [
-        {
-          messageId: 'default',
-          column: 1,
-          endColumn: 27,
-        },
-      ],
+      code: "assert.ok(find('.foo')[0], 'custom message');",
+      output: "assert.dom('.foo').exists('custom message');",
+      errors: [{ messageId: 'ok' }],
+    },
+
+    {
+      code: "assert.ok(find('.foo', '.parent-scope'));",
+      output: "assert.dom('.foo', '.parent-scope').exists();",
+      errors: [{ messageId: 'ok' }],
+    },
+    {
+      code: "assert.ok(find('.foo', '.parent-scope')[0]);",
+      output: "assert.dom('.foo', '.parent-scope').exists();",
+      errors: [{ messageId: 'ok' }],
+    },
+
+    {
+      code: "assert.equal(find('.foo'), true);",
+      output: "assert.dom('.foo').exists();",
+      errors: [{ messageId: 'equal-true' }],
+    },
+    {
+      code: "assert.equal(find('.foo')[0], true);",
+      output: "assert.dom('.foo').exists();",
+      errors: [{ messageId: 'equal-true' }],
+    },
+
+    {
+      code: "assert.equal(find('.foo'), true, 'custom message');",
+      output: "assert.dom('.foo').exists('custom message');",
+      errors: [{ messageId: 'equal-true' }],
+    },
+    {
+      code: "assert.equal(find('.foo')[0], true, 'custom message');",
+      output: "assert.dom('.foo').exists('custom message');",
+      errors: [{ messageId: 'equal-true' }],
+    },
+
+    {
+      code: "assert.equal(find('.foo', '.parent-scope'), true);",
+      output: "assert.dom('.foo', '.parent-scope').exists();",
+      errors: [{ messageId: 'equal-true' }],
+    },
+    {
+      code: "assert.equal(find('.foo', '.parent-scope')[0], true);",
+      output: "assert.dom('.foo', '.parent-scope').exists();",
+      errors: [{ messageId: 'equal-true' }],
+    },
+
+    // from https://github.com/simplabs/qunit-dom-codemod/blob/master/__testfixtures__/qunit-dom-codemod/not-ok-find.input.js
+
+    {
+      code: "assert.notOk(find('.foo'));",
+      output: "assert.dom('.foo').doesNotExist();",
+      errors: [{ messageId: 'not-ok' }],
+    },
+    {
+      code: "assert.notOk(find('.foo')[0]);",
+      output: "assert.dom('.foo').doesNotExist();",
+      errors: [{ messageId: 'not-ok' }],
+    },
+    {
+      code: 'assert.notOk(find(foo));',
+      output: 'assert.dom(foo).doesNotExist();',
+      errors: [{ messageId: 'not-ok' }],
+    },
+    {
+      code: 'assert.notOk(find(foo.bar));',
+      output: 'assert.dom(foo.bar).doesNotExist();',
+      errors: [{ messageId: 'not-ok' }],
+    },
+
+    {
+      code: "assert.notOk(find('.foo'), 'custom message');",
+      output: "assert.dom('.foo').doesNotExist('custom message');",
+      errors: [{ messageId: 'not-ok' }],
+    },
+    {
+      code: "assert.notOk(find('.foo')[0], 'custom message');",
+      output: "assert.dom('.foo').doesNotExist('custom message');",
+      errors: [{ messageId: 'not-ok' }],
+    },
+
+    {
+      code: "assert.notOk(find('.foo', '.parent-scope'));",
+      output: "assert.dom('.foo', '.parent-scope').doesNotExist();",
+      errors: [{ messageId: 'not-ok' }],
+    },
+    {
+      code: "assert.notOk(find('.foo', '.parent-scope')[0]);",
+      output: "assert.dom('.foo', '.parent-scope').doesNotExist();",
+      errors: [{ messageId: 'not-ok' }],
+    },
+
+    {
+      code: "assert.equal(find('.foo'), false);",
+      output: "assert.dom('.foo').doesNotExist();",
+      errors: [{ messageId: 'equal-false' }],
+    },
+    {
+      code: "assert.equal(find('.foo')[0], false);",
+      output: "assert.dom('.foo').doesNotExist();",
+      errors: [{ messageId: 'equal-false' }],
+    },
+
+    {
+      code: "assert.equal(find('.foo'), false, 'custom message');",
+      output: "assert.dom('.foo').doesNotExist('custom message');",
+      errors: [{ messageId: 'equal-false' }],
+    },
+    {
+      code: "assert.equal(find('.foo')[0], false, 'custom message');",
+      output: "assert.dom('.foo').doesNotExist('custom message');",
+      errors: [{ messageId: 'equal-false' }],
+    },
+
+    {
+      code: "assert.equal(find('.foo', '.parent-scope'), false);",
+      output: "assert.dom('.foo', '.parent-scope').doesNotExist();",
+      errors: [{ messageId: 'equal-false' }],
+    },
+    {
+      code: "assert.equal(find('.foo', '.parent-scope')[0], false);",
+      output: "assert.dom('.foo', '.parent-scope').doesNotExist();",
+      errors: [{ messageId: 'equal-false' }],
     },
   ],
 });


### PR DESCRIPTION
This reimplements the `no-ok-find` rule roughly based on the original implementation in https://github.com/simplabs/qunit-dom-codemod/blob/bf853ee4fc2929cd2aae1be6a750a8795e4b96c2/qunit-dom-codemod.js#L288-L320

Changes in this reimplementation:
- ignores selectors with JQuery selectors
- supports `assert.equal(find(...), true|false)`
- ignores `assert.strictEqual(find(...), true|false)`
- supports scope parameters (e.g. `assert.ok(find('.foo', '.parent-scope'))`)