### PR TITLE
no-ok-find: Fix false positive due to incorrect regex

### DIFF
--- a/rules/no-ok-find.js
+++ b/rules/no-ok-find.js
@@ -2,7 +2,7 @@ const OK_OR_NOTOK_SELECTOR =
   'CallExpression' +
   '[callee.type="MemberExpression"]' +
   '[callee.object.name="assert"]' +
-  '[callee.property.name=/(ok|notOk)/]' +
+  '[callee.property.name=/^(ok|notOk)$/]' +
   '[arguments.length>=1]';
 
 const EQUAL_SELECTOR =

--- a/rules/no-ok-find.test.js
+++ b/rules/no-ok-find.test.js
@@ -18,6 +18,7 @@ ruleTester.run('no-ok-find', rule, {
     'assert.ok(1);',
     "assert.ok(notFind('.foo'));",
     'assert.ok(find());',
+    "assert.token(find('.foo'));",
 
     "notAssert.notOk(find('.foo'));",
     'assert.notOk;',


### PR DESCRIPTION
`/ok/` also catches the substring "ok" in e.g. "token". `/^ok$/` is what we want, which only catches exactly "ok", but not as a substring in a longer string.